### PR TITLE
Wiringpiラッパーをclispi内に移動する

### DIFF
--- a/skeleton/project/app.lisp
+++ b/skeleton/project/app.lisp
@@ -1,6 +1,6 @@
 (uiop:define-package #:<% @var name %>/app
   (:use #:cl
-        #:<% @var name %>/wrapper/wiringpi)
+        #:clispi/wiringpi-wrapper)
   (:export #:main))
 (in-package #:<% @var name %>/app)
 

--- a/skeleton/project/skeleton.asd
+++ b/skeleton/project/skeleton.asd
@@ -5,6 +5,7 @@
   :license "<% @var license %>"
   :description "<% @var description %>"
   :depends-on ("cffi"
+               "clispi"
                "<% @var name %>/boot"
                "cl-syntax-annot"))
 

--- a/wiringpi-wrapper.lisp
+++ b/wiringpi-wrapper.lisp
@@ -1,4 +1,4 @@
-(uiop:define-package #:<% @var name %>/wrapper/wiringpi
+(defpackage #:clispi/wiringpi-wrapper
   (:use #:cl #:cffi)
   (:export #:+input+
            #:+output+
@@ -8,25 +8,41 @@
            #:+pud-off+
            #:+pud-down+
            #:+pud-up+
+
+           ;; Setup
            #:wiringpi-setup-gpio
+
+           ;; Core Function
            #:pin-mode
-           #:digital-read
-           #:digital-write
            #:pull-updn-control
+           #:digital-write
+           #:pwm-write
+           #:digital-read
+           #:analog-read
+           #:analog-write
+
+           ;; Raspberry Pi Specifics
            #:pwm-set-mode
            #:pwm-set-range
            #:pwm-set-clock
-           #:pwm-write
-           #:soft-pwm-create
-           #:soft-pwm-write
-           #:wiringpi-i2c-setup
-           #:wiringpi-i2c-write-reg8
-           #:wiringpi-i2c-read
-           #:wiringpi-i2c-read-reg16
+
+           ;; Timing
+           #:delay
+
+           ;; SPI Library
            #:wiringpi-spi-setup
            #:wiringpi-spi-data-rw
-           #:delay))
-(in-package #:<% @var name %>/wrapper/wiringpi)
+
+           ;; I2C Library
+           #:wiringpi-i2c-setup
+           #:wiringpi-i2c-read
+           #:wiringpi-i2c-write-reg8
+           #:wiringpi-i2c-read-reg16
+
+           ;; Software PWM Library
+           #:soft-pwm-create
+           #:soft-pwm-write))
+(in-package #:clispi/wiringpi-wrapper)
 
 (define-foreign-library libwiringPi
   (:unix "libwiringPi.so")


### PR DESCRIPTION
Wiringpiラッパーをclispi内に移動してskeltonプロジェクトに依存しないようにする